### PR TITLE
Add i18n support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,5 +20,11 @@ npm run build
 npm run lint
 ```
 
+### Language Switch
+The application now supports Chinese and English. Use the language selector in the page header to switch languages. Preference is stored in `localStorage`.
+
+### Additional Dependency
+`vue-i18n` is used for internationalization.
+
 ### Customize configuration
 See [Configuration Reference](https://cli.vuejs.org/config/).

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "uglifyjs-webpack-plugin": "^1.1.1",
     "vue": "^2.6.11",
     "vue-fragment": "^1.5.2",
+    "vue-i18n": "^8.x",
     "vue-router": "^3.2.0",
     "vuex": "^3.4.0"
   },

--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -1,0 +1,15 @@
+import Vue from 'vue';
+import VueI18n from 'vue-i18n';
+import en from './lang/en';
+import zh from './lang/zh';
+
+Vue.use(VueI18n);
+const messages = { en, zh };
+
+const i18n = new VueI18n({
+  locale: localStorage.getItem('lang') || 'zh',
+  fallbackLocale: 'en',
+  messages,
+});
+
+export default i18n;

--- a/src/i18n/lang/en.js
+++ b/src/i18n/lang/en.js
@@ -1,0 +1,30 @@
+export default {
+  login: {
+    username: 'Username',
+    password: 'Password',
+    login: 'Login',
+    error: 'Incorrect username or password',
+    empty: 'Please enter correct username and password',
+  },
+  header: {
+    welcome: 'Welcome to the Medical Management System, current user: ',
+    logout: 'Logout',
+    loggedOut: 'Logged out',
+  },
+  notFound: {
+    back: 'Leave this page',
+    success: 'You are back on the right path',
+  },
+  home: {
+    dashboard: 'Dashboard',
+    home: 'Home',
+    doctor: 'Doctors',
+    drug: 'Drug Types',
+    company: 'Companies',
+    sale: 'Pharmacies',
+    hospital: 'Hospital Departments',
+    latest: 'Latest Policy',
+    policy: 'Latest Medical Policy',
+    companyPolicy: 'Latest Company Policy'
+  }
+};

--- a/src/i18n/lang/zh.js
+++ b/src/i18n/lang/zh.js
@@ -1,0 +1,30 @@
+export default {
+  login: {
+    username: '用户名',
+    password: '密码',
+    login: '登录',
+    error: '账号或密码错误',
+    empty: '请输入正确的用户名密码',
+  },
+  header: {
+    welcome: '欢迎来到慧医数字医疗应用系统，当前用户：',
+    logout: '退出登录',
+    loggedOut: '已退出登录',
+  },
+  notFound: {
+    back: '离开这个是非之地',
+    success: '你回到了正确的道路上',
+  },
+  home: {
+    dashboard: '数据面板',
+    home: '首页',
+    doctor: '医师人数',
+    drug: '药物种类',
+    company: '合作企业',
+    sale: '入驻药店',
+    hospital: '医院科室',
+    latest: '最新政策',
+    policy: '最新医保政策',
+    companyPolicy: '最新医药公司政策'
+  }
+};

--- a/src/layout/components/PageHeader/index.vue
+++ b/src/layout/components/PageHeader/index.vue
@@ -5,14 +5,14 @@
     </div>
     <div class="main-head">
       <div class="main-head-right">
-        <span
-          >欢迎来到慧医数字医疗应用系统，当前用户：<span id="username">{{
-            userName
-          }}</span></span
-        >
+        <span>{{ $t('header.welcome') }}<span id="username">{{ userName }}</span></span>
+        <el-select v-model="lang" size="mini" @change="changeLang" style="margin-left: 10px;">
+          <el-option label="中文" value="zh" />
+          <el-option label="English" value="en" />
+        </el-select>
         <div class="exit-area" @click="handleLogout">
           <p class="iconfont icon-tuichu"></p>
-          <p class="logout">退出登录</p>
+          <p class="logout">{{ $t('header.logout') }}</p>
         </div>
       </div>
     </div>
@@ -22,14 +22,23 @@
 <script>
 export default {
   name: "PageHeader",
+  data() {
+    return {
+      lang: localStorage.getItem('lang') || 'zh',
+    };
+  },
   methods: {
 
     handleLogout() {
       localStorage.removeItem("token");
       localStorage.removeItem("userInfo");
-      this.$message.warning("已退出登录");
+      this.$message.warning(this.$t('header.loggedOut'));
       this.$router.replace("/user/login");
       this.$router.go(0);
+    },
+    changeLang(val) {
+      this.$i18n.locale = val;
+      localStorage.setItem('lang', val);
     },
   },
   computed: {

--- a/src/main.js
+++ b/src/main.js
@@ -6,6 +6,7 @@ import store from "./store";
 import _ from 'lodash'
 import "./style/reset.css";
 import "./plugins/element.js";
+import i18n from "./i18n";
 import Fragment from "vue-fragment";
 import "animate.css";
 
@@ -32,5 +33,6 @@ Vue.mixin({
 new Vue({
     router,
     store,
+    i18n,
     render: (h) => h(App),
 }).$mount("#app");

--- a/src/plugins/element.js
+++ b/src/plugins/element.js
@@ -1,5 +1,8 @@
 import Vue from "vue";
 import Element from "element-ui";
 import "element-ui/lib/theme-chalk/index.css";
+import locale from "element-ui/lib/locale";
+import i18n from "../i18n";
 
-Vue.use(Element);
+Vue.use(Element, { i18n: (key, value) => i18n.t(key, value) });
+locale.i18n((key, value) => i18n.t(key, value));

--- a/src/views/404/index.vue
+++ b/src/views/404/index.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="bg-container">
-    <el-button @click="backHome" class="back-home">离开这个是非之地</el-button>
+    <el-button @click="backHome" class="back-home">{{ $t('notFound.back') }}</el-button>
   </div>
 </template>
 
@@ -12,7 +12,7 @@ export default {
       setTimeout(() => {
         this.$router.replace("/");
       }, 200);
-      this.$message.success("你回到了正确的道路上");
+      this.$message.success(this.$t('notFound.success'));
     },
   },
 };

--- a/src/views/Home/index.vue
+++ b/src/views/Home/index.vue
@@ -2,11 +2,11 @@
   <el-container>
     <!-- 头部区域 -->
     <el-header height="76px">
-      <h2>数据面板</h2>
+      <h2>{{ $t('home.dashboard') }}</h2>
       <!-- 面包屑导航区域 -->
       <el-breadcrumb separator="/">
-        <el-breadcrumb-item :to="{ path: '/' }">首页</el-breadcrumb-item>
-        <el-breadcrumb-item>数据面板</el-breadcrumb-item>
+        <el-breadcrumb-item :to="{ path: '/' }">{{ $t('home.home') }}</el-breadcrumb-item>
+        <el-breadcrumb-item>{{ $t('home.dashboard') }}</el-breadcrumb-item>
       </el-breadcrumb>
     </el-header>
     <!-- 主体内容区域 -->
@@ -17,7 +17,7 @@
           <div class="square">
             <div icon-class="doc" class="icon" />
             <div class="title">
-              <div class="subtitle">医师人数</div>
+              <div class="subtitle">{{ $t('home.doctor') }}</div>
               <div class="number">{{ doctors }}</div>
             </div>
           </div>
@@ -25,7 +25,7 @@
           <div class="square">
             <div icon-class="bag" class="icon" />
             <div class="title">
-              <div class="subtitle">药物种类</div>
+              <div class="subtitle">{{ $t('home.drug') }}</div>
               <div class="number">{{ drugs }}</div>
             </div>
           </div>
@@ -33,7 +33,7 @@
           <div class="square">
             <div icon-class="operation" class="icon" />
             <div class="title">
-              <div class="subtitle">合作企业</div>
+              <div class="subtitle">{{ $t('home.company') }}</div>
               <div class="number">{{ companies }}</div>
             </div>
           </div>
@@ -41,7 +41,7 @@
           <div class="square">
             <div icon-class="patient" class="icon" />
             <div class="title">
-              <div class="subtitle">入驻药店</div>
+              <div class="subtitle">{{ $t('home.sale') }}</div>
               <div class="number">{{ sales }}</div>
             </div>
           </div>
@@ -58,15 +58,15 @@
         <!-- 销售城市量柱状图表 -->
         <div class="chartcontainer">
           <div class="rectangle">
-            <h1 style="color: gray">医院科室</h1>
+            <h1 style="color: gray">{{ $t('home.hospital') }}</h1>
             <div id="piechart" class="piechart"></div>
           </div>
 
           <div class="rectangle">
-            <h1 style="color: gray">最新政策</h1>
+            <h1 style="color: gray">{{ $t('home.latest') }}</h1>
             <div style="float: left; width: 100%">
               <el-table :data="materials" stripe style="width: 100%">
-                <el-table-column prop="notice" label="最新医保政策" width="450">
+                <el-table-column prop="notice" :label="$t('home.policy')" width="450">
                   <template slot-scope="scope">
                     <div>{{ scope.row.notice }}</div>
                   </template>
@@ -81,7 +81,7 @@
             </div>
             <div style="float: left; width: 100%">
               <el-table :data="policys" stripe style="width: 100%">
-                <el-table-column prop="notice" label="最新医药公司政策" width="450">
+                <el-table-column prop="notice" :label="$t('home.companyPolicy')" width="450">
                   <template slot-scope="scope">
                     <div>{{ scope.row.notice }}</div>
                   </template>

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -12,7 +12,7 @@
                             type="text"
                             v-model="loginForm.username"
                             autocomplete="off"
-                            placeholder="用户名"
+                            :placeholder="$t('login.username')"
                     />
                 </div>
               </el-form-item>
@@ -24,7 +24,7 @@
                             type="password"
                             v-model="loginForm.password"
                             autocomplete="off"
-                            placeholder="密码"
+                            :placeholder="$t('login.password')"
                             @keydown.enter="handleLogin('loginForm')"
                     />
                 </div>
@@ -158,12 +158,12 @@ export default {
               // }, 1200);
             })
             .catch(() => {
-              this.$message.error("账号或密码错误");
+              this.$message.error(this.$t('login.error'));
             });
         } else {
           this.$notify.error({
             title: " 错误",
-            message: " 请输入正确的用户名密码",
+            message: this.$t('login.empty'),
           });
 
           return false;


### PR DESCRIPTION
## Summary
- include vue-i18n dependency
- add i18n setup with English and Chinese locales
- integrate i18n with Element UI
- inject i18n instance into Vue
- add language switcher in header
- update some components to use translated text
- document new feature

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686e69f42970832cabf5dcca92a42f41