### PR TITLE
Fix i18n for menu and Element UI

### DIFF
--- a/src/i18n/index.js
+++ b/src/i18n/index.js
@@ -1,10 +1,15 @@
 import Vue from 'vue';
 import VueI18n from 'vue-i18n';
+import enLocale from 'element-ui/lib/locale/lang/en';
+import zhLocale from 'element-ui/lib/locale/lang/zh-CN';
 import en from './lang/en';
 import zh from './lang/zh';
 
 Vue.use(VueI18n);
-const messages = { en, zh };
+const messages = {
+  en: { ...enLocale, ...en },
+  zh: { ...zhLocale, ...zh }
+};
 
 const i18n = new VueI18n({
   locale: localStorage.getItem('lang') || 'zh',

--- a/src/i18n/lang/en.js
+++ b/src/i18n/lang/en.js
@@ -18,6 +18,7 @@ export default {
   menu: {
     '首页': 'Home',
     '医药公司信息管理': 'Company Management',
+    '医药公司管理': 'Company Management',
     '销售地点管理': 'Sales Location Management',
     '城市信息管理': 'City Management',
     '药品信息管理': 'Drug Management',
@@ -48,6 +49,14 @@ export default {
   },
   cityManage: {
     list: 'City List'
+  },
+  el: {
+    pagination: {
+      goto: 'Go to',
+      pagesize: '/page',
+      total: 'Total {total}',
+      pageClassifier: ''
+    }
   },
   home: {
     dashboard: 'Dashboard',

--- a/src/i18n/lang/zh.js
+++ b/src/i18n/lang/zh.js
@@ -18,6 +18,7 @@ export default {
   menu: {
     '首页': '首页',
     '医药公司信息管理': '医药公司信息管理',
+    '医药公司管理': '医药公司管理',
     '销售地点管理': '销售地点管理',
     '城市信息管理': '城市信息管理',
     '药品信息管理': '药品信息管理',
@@ -48,6 +49,14 @@ export default {
   },
   cityManage: {
     list: '城市列表'
+  },
+  el: {
+    pagination: {
+      goto: '前往',
+      pagesize: '条/页',
+      total: '共 {total} 条',
+      pageClassifier: '页'
+    }
   },
   home: {
     dashboard: '数据面板',


### PR DESCRIPTION
## Summary
- integrate Element UI locales with `vue-i18n`
- add missing menu key `医药公司管理`
- provide pagination translations for Element UI

## Testing
- `npm run lint` *(fails: vue-cli-service not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e809f3674832c97fb77bd075cdfc5